### PR TITLE
Fix for loadFile() when used repeatedly. Added getFloatsInColumn()

### DIFF
--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -494,4 +494,23 @@ namespace wng {
         }
         if ( data[ row ].size() <= col ) data[ row ].push_back("");
     }
+    
+    
+    
+    /**
+     * getFloatsInColumn
+     * Converts all rows in the given column to floats.
+     *
+     * When you are done with the object, make sure to delete it.
+     */
+    vector<float>* ofxCsv::getFloatsInColumn(int col) {
+        vector<float>* result = new vector<float>(numRows);
+        
+        for (int i = 0; i < numRows; i++) {
+            auto val = this->getFloat(i, col);
+            result->at(i) = (val);
+        }
+        
+        return result;
+    }
 }

--- a/src/ofxCsv.cpp
+++ b/src/ofxCsv.cpp
@@ -58,7 +58,7 @@ namespace wng {
 	
 	
 	/**
-	 * Load a CSV File.
+	 * Load a CSV File. Discards any previously loaded CSV data.
 	 *
 	 * @param path
 	 *        Set the File path.
@@ -68,7 +68,9 @@ namespace wng {
 	 *        Set the Comments sign.
 	 */
 	void ofxCsv::loadFile(string path, string separator, string comments){
-		
+        // discard any previous file data.
+        clear();
+        
 		// Save Filepath, Separator and Comments to variables.
 		filePath = path;
 		fileSeparator = separator;
@@ -127,11 +129,13 @@ namespace wng {
 			rows.erase(rows.begin(), rows.end());
 			//cout << "rows: After erasing all elements, vector integers " << (rows.empty() ? "is" : "is not" ) << " empty" << endl;
 		
+            // close file now that we're done with it to free up resources.
+            fileIn.close();
+            
 			// If File cannot opening, print a message to console.
 		} else {
 			cerr << "[ofxCsv] Error opening " << path << ".\n";
 		}
-	
 	}
     
     void ofxCsv::setData( vector<vector<string> > data)

--- a/src/ofxCsv.h
+++ b/src/ofxCsv.h
@@ -78,6 +78,9 @@ namespace wng {
 			float  getFloat(int row, int col);
 			string getString(int row, int col);
 			bool   getBool(int row, int col);
+        
+            // converts entire rows into vectors of new datatype
+            vector<float>* getFloatsInColumn(int col);
 		
 			void setInt(int row, int col, int what);
 			void setFloat(int row, int col, float what);


### PR DESCRIPTION
I'm not sure if it's a bug or intended behavior, but when I load multiple CSV files using the same ofxCsv object, it was appending the data to the previous file's data, instead of only using the new file's data. This PR makes sure that each time you call loadFile(), the previous data is wiped out and resources disposed. 

**This will change functionality that depends on data being appended by loadFile().** I'm unclear what would happen in that case if the files have different numbers of columns, though.
